### PR TITLE
更新插件：雪球菜单v2

### DIFF
--- a/雪球菜单v2/__init__.py
+++ b/雪球菜单v2/__init__.py
@@ -129,9 +129,14 @@ class SnowMenu(Plugin):
                 self.page = None
                 self.event.set()
         cb = _cb()
+        if isinstance(disp_func, dict):
+            # shh, 这是一个秘密
+            page_cb = lambda _, now_page: disp_func.get(now_page)
+        else:
+            page_cb = disp_func
         page = MultiPage(
             page_id = None,
-            page_cb = disp_func,
+            page_cb = page_cb,
             ok_cb = cb.ok,
             exit_cb = cb.exit,
             leave_cb = cb.exit

--- a/雪球菜单v2/datas.json
+++ b/雪球菜单v2/datas.json
@@ -1,6 +1,6 @@
 {
   "author": "SuperScript",
-  "version": "0.0.7",
+  "version": "0.0.8",
   "description": "贴合租赁服原汁原味的雪球菜单！ 可以自定义雪球菜单内容， 同时也是一个API插件.\n§f使用前请先传送到指令区后输入命令§b.snowmenu-init§f初始化雪球菜单命令方块！\n在配置文件内向雪球菜单添加内容。\n0.0.4: 源码内内置API文档",
   "plugin-type": "classic",
   "pre-plugins": {


### PR DESCRIPTION
- 在`simple_select`函数中，使用threading.Event()替换while 1和time.sleep来处理菜单请求
- 由于需要兼顾玩家退出的问题，静态页面和动态页面类新增leave_cb，这样一来`simple_select`函数就能检测玩家退出并取消阻塞了
- 在切换页面后立刻刷新菜单显示
- 玩家雪球菜单的确认/退出异常来源于服务器内的`snowmenu`tag与插件`in_snowball_menu`字典的不同步，所以在出现此类异常时发送一次移除tag的命令