### PR TITLE
点歌台 : Remove Accept-Encoding header from request headers

### DIFF
--- a/点歌台/__init__.py
+++ b/点歌台/__init__.py
@@ -85,7 +85,6 @@ class DJTable(Plugin):
         headers = {
             "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36 Edg/145.0.0.0",
             "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7",
-            "Accept-Encoding": "gzip, deflate, br, zstd",
             "Accept-Language": "zh-CN,zh;q=0.9,en;q=0.8,en-GB;q=0.7,en-US;q=0.6",
             "Connection": "keep-alive",
             "Host": "www.midishow.com",


### PR DESCRIPTION
Removed 'Accept-Encoding' header from request.

Midishow 现在会跟据请求头返回压缩的数据 我们没有解压 直接不允许压缩